### PR TITLE
Adding missing link to lxml under requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ PCBmodE gives the designer the freedome to place any arbitrary shape on any laye
 You'll need:
 * Python 2.7
 * [PyParsing](http://pyparsing.wikispaces.com/)
+* [lxml](http://lxml.de/index.html)
 * [Inkscape](http://inkscape.org)
 
 PCBmodE is developed and tested under Linux, so it might or might not work under other OSs. (It'd be helpful to know success or failure of attempts!)


### PR DESCRIPTION
Just adding a link to the missing prerequisit "lxml"

It works under Mac OS X as well. I tried "hello-flowers", I had to copy "components" into a sub-folder called Hello-Flowers though. 