### PR TITLE
A few tweaks for --fab oshpark

### DIFF
--- a/pcbmode_config.json
+++ b/pcbmode_config.json
@@ -159,13 +159,15 @@
           {
             "copper": {"ext": "GTL"},
             "soldermask": {"ext": "GTS"},
-            "silkscreen": {"ext": "GTO"}
+            "silkscreen": {"ext": "GTO"},
+            "solderpaste": {"ext": "GTP"}
           },
           "bottom":
           {
             "copper": {"ext": "GBL"},
             "soldermask": {"ext": "GBS"},
-            "silkscreen": {"ext": "GBO"}  
+            "silkscreen": {"ext": "GBO"},
+            "solderpaste": {"ext": "GBP"}
           },
           "other":
    	  {

--- a/utils/gerber.py
+++ b/utils/gerber.py
@@ -78,8 +78,11 @@ def gerberise(manufacturer='default'):
                             steps,
                             length)
 
-            add = '_%s_%s.%s' % (pcb_layer, sheet,
-                                 filename_info[pcb_layer][sheet].get('ext') or 'ger')
+            try:
+                ext = filename_info[pcb_layer][sheet]['ext']
+            except KeyError:
+                ext = 'ger'
+            add = '_%s_%s.%s' % (pcb_layer, sheet, ext)
             filename = os.path.join(base_dir, base_name + add)
 
             with open(filename, "wb") as f:


### PR DESCRIPTION
Did an end-to-end test for submitting designs to OSH Park and got this:

```
...
-- Creating Gerbers
Traceback (most recent call last):
  File "pcbmode/pcbmode.py", line 371, in <module>
    main()
  File "pcbmode/pcbmode.py", line 343, in main
    gerber.gerberise(manufacturer)
  File "/Users/grant/Platforms/pcbmode/pcbmode/utils/gerber.py", line 82, in gerberise
    filename_info[pcb_layer][sheet].get('ext') or 'ger')
KeyError: 'solderpaste'
```

So, add the missing extensions and really fall back on `ger` if nothing is specified in the config.
