### PR TITLE
Update setup instructions

### DIFF
--- a/docs/source/hello-solder.rst
+++ b/docs/source/hello-solder.rst
@@ -11,7 +11,7 @@ Setup
 
 Get the boards repository from `here <https://github.com/boldport/boards>`_ and follow the instructions :doc:`setup` to 'compile' the board. This command should do it
 
-    ``python pcbmode/pcbmode.py -b hello-solder -m``
+    ``pcbmode -b hello-solder -m``
 
 
 .. info:: *PCBmodE* caches some of the heavy computations in a file in the ``build`` directory, so subsequent invocations will run much faster.

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -4,18 +4,73 @@ Setup
 
 *PCBmodE* is written and tested with Python 2.7 under Linux. It may or may not work on other operating systems or later versions of Python. With time 'official' support for Windows/MAC will be added.
 
+It comes in the form of a installable tool called `pcbmode` which is
+run from the command line.
+
 What you'll need
 ================
 
-* Linux
-* Python 2.7 + PyParsing package
+* Python 2.7
 * Inkscape
 * Text editor
 
-Setup
-=====
+Installation from Source with Virtualenv
+========================================
 
-.. tip:: To see all the options that *PCBmodE* supports, use ``python pcbmode.py --help``
+Virualenv is a Python tool that makes it easy to keep applications in
+their own isolated environments. As a bonus, root permissions are not
+required. This can come useful when running experimental versions of
+PCBmodE.
+
+These instructions describe how to build PCBmodE for use in a
+virtualenv. To be able to build python-lxml (one of PCBmodE's
+dependencies) you need to install some system-level development
+packages. On Debian based systems these are installed like this:
+
+.. code-block:: bash
+
+                sudo apt-get install libxml2-dev libxslt1-dev python-dev
+
+Fetch the *PCBModE* source. Stable snapshots are available at
+`https://github.com/boldport/pcbmode/releases
+<https://github.com/boldport/pcbmode/releases>`_. The latest
+development sources are available via git:
+
+.. code-block:: bash
+
+                git clone https://github.com/boldport/pcbmode.git
+
+After putting PCBmodE in a directory called `pcbmode`, run these
+commands to create a virtualenv in the directory `pcbmode-env/` next
+to it, and install PCBmodE in the virtualenv.
+
+.. code-block:: bash
+
+                virtualenv pcbmode-env
+                source pcbmode-env/bin/activate
+		cd pcbmode
+		python setup.py install
+
+After installation, PCBmodE will be available in your path as
+``pcbmode``. But since it was installed in a virtualenv, the
+``pcbmode`` command will only be available in your path after running
+``pcbmode-env/bin/activate`` and will no longer be in your path after
+running ``deactivate``. You will need to activate the virtualenv each
+time you want to run `pcbmode` from a new terminal window.
+
+Nothing is installed globally, so to start from scratch you can just follow these steps:
+
+.. code-block:: bash
+
+                deactivate         # skip if pcbmode-env is not active
+                rm -r pcbmode-env
+                cd pcbmode
+                git clean -dfX     # erases any untracked files (build files etc). save your work!
+
+Running PCBmodE
+===============
+
+.. tip:: To see all the options that *PCBmodE* supports, use ``pcbmode --help``
 
 By default *PCBmodE* expects to find the board files under
 
@@ -41,7 +96,7 @@ Here's one way to organise the build environment
 
 To make the ``hello-solder`` board, run *PCBmodE* within ``cool-pcbs``
 
-    python PCBmodeE/pcbmode.py -b hello-solder -m
+    pcbmode -b hello-solder -m
 
 Then open the SVG with Inkscape
 


### PR DESCRIPTION
The current state of the code requires the code to be installed as a
package before using it. This commit updates the setup instructions so
that they reflect the current state of the code.

This change is based on the work in progress by user nocko on
GitHub. I reused the parts relating to building from source with
virtualenv. The other methods (installing binary packages) are not
available yet, so I skipped them.

Changes:

- Replace "python PCBmodeE/pcbmode.py" by "pcbmode"
- New section on Setup page: "Installation from Source with virtualenv"