### PR TITLE
Fix _makeRelative bug for SVG H commands

### DIFF
--- a/pcbmode/utils/svgpath.py
+++ b/pcbmode/utils/svgpath.py
@@ -314,7 +314,7 @@ class SvgPath():
      
                 if path[i][0] == 'H':
                     for coord_tmp in path[i][1:]:
-                        coord.assign(coord_tmp[0], coord_tmp[1])
+                        coord.assign(coord_tmp[0], 0)
                         p += str(coord.x - abspos.x) + ' '
                         abspos.x = coord.x
      


### PR DESCRIPTION
Discovered this while writing tests - in an SVG path, the absolute form of the horizontal line command always fails because _makeRelative is trying to use the nonexistent y-coordinate.