### PR TITLE
Fix _makeRelative for SVG Q command

### DIFF
--- a/pcbmode/utils/svgpath.py
+++ b/pcbmode/utils/svgpath.py
@@ -244,10 +244,11 @@ class SvgPath():
                         abspos += coord 
      
                 if path[i][0] == 'Q':
-                    for coord_tmp in path[i][1:]:
-                        coord.assign(coord_tmp[0], coord_tmp[1])
-                        p += str(coord.x - abspos.x) + ',' + str(coord.y - abspos.y) + ' '
-                    abspos.assign(coord.x, coord.y)
+                    for j in range(1,len(path[i])+1, 2):
+                        for coord_tmp in path[i][j:j+2]:
+                            coord.assign(coord_tmp[0], coord_tmp[1])
+                            p += str(coord.x - abspos.x) + ',' + str(coord.y - abspos.y) + ' '
+                        abspos.assign(coord.x, coord.y)
      
      
             # simple cubic Bezier curve command 


### PR DESCRIPTION
When pcbmode.utils.svgpath._makeRelative processes a Q command, it takes
the current absolute point as a reference and converts all the
coordinates to be relative to that point.

The SVG Q command actually expects the current point to be updated with
each step in the path, so _makeRelative needs to update the absolute
point with the 'end point' of each step in the path as it goes.

Example:

    M5,5 Q15,10 25,5 35,0 45,5

is a two-step quadratic bezier curve which should become this relative
path:

    M5,5 q10,5 20,0 10,-5 20,0

where the second step is relative to the endpoint of the first.