### PR TITLE
Corrected print statement to make it compatible with Python 3.7

### DIFF
--- a/pcbmode/pcbmode.py
+++ b/pcbmode/pcbmode.py
@@ -372,13 +372,13 @@ def makeConfig(name, version, cmdline_args):
       "outline": { "place": True, "hide": False, "lock": True }
     }
 
-    # Get overrides
+    # Assign Layer Control Defaults
+    config.brd['layer-control'] = layer_control_default
+
+    # Then get overrides
     layer_control_config = config.brd.get('layer-control')
     if layer_control_config != None:
-        config.brd['layer-control'] = dict(layer_control_default.items() +
-                                           layer_control_config.items())
-    else:
-        config.brd['layer-control'] = layer_control_default
+        config.brd['layer-control'].update(layer_control_config)
 
 
     return

--- a/pcbmode/utils/utils.py
+++ b/pcbmode/utils/utils.py
@@ -349,7 +349,7 @@ def checkForPoursInLayer(layer):
         pours = {}
 
     if pours is not None:
-        print pours
+        print(pours)
         for pour_dict in pours:
             layers = getExtendedLayerList(pour_dict.get('layers'))
             if layer in layers:


### PR DESCRIPTION
All the PCBmodE code - bar one print statement - ran perfectly under Python 3.7.

This simple correction resolves that issue.