### PR TITLE
Fix generation of _path_in in non-string svgpaths.

### DIFF
--- a/pcbmode/utils/svgpath.py
+++ b/pcbmode/utils/svgpath.py
@@ -50,6 +50,8 @@ class SvgPath:
             self._p_r_path = self._p_path_to_relative(self._p_path)
         else:
             self._p_r_path = path_in
+            self._stringify_path()
+            self._path_in = self._s_r_path
 
         # Transform path
         self._t_dict = trans_dict


### PR DESCRIPTION
Probably svgpaths shouldn't be initialized from both strings and lists, but if they are to be, then when we generate from lists I think we need to also create _path_in (before transformations) in __init__ in order to use get_input_path.

I'm a toddler with a shotgun in this codebase, so please review to see that it makes sense. Before the fix, non-path outline types ("circle", "rect", etc.) could not be specified.